### PR TITLE
Separating out the transform position function for presence from the OT one

### DIFF
--- a/lib/text0.js
+++ b/lib/text0.js
@@ -143,13 +143,44 @@ text.normalize = function(op) {
 var transformPosition = function(pos, c, insertAfter) {
   // This will get collapsed into a giant ternary by uglify.
   if (c.i != null) {
-     // Stian 21/4/2020: Originally there was insertAfter, but this caused a bug
-     // where selecting text, then deleting it by typing a letter would get
-     // misinterpreted. Seems to me that we want to push the cursor even by
-     // normal typing. Perhaps this is because we don't send position updates
-     // when typing, while others do? Hopefully changing this doesn't introduce
-     // other bugs.
-     if (c.p < pos || (c.p === pos)) { // && insertAfter)) {== pos && insertAfter)) {
+    if (c.p < pos || (c.p === pos && insertAfter)) {
+      return pos + c.i.length;
+    } else {
+      return pos;
+    }
+  } else {
+    // I think this could also be written as: Math.min(c.p, Math.min(c.p -
+    // otherC.p, otherC.d.length)) but I think its harder to read that way, and
+    // it compiles using ternary operators anyway so its no slower written like
+    // this.
+    if (pos <= c.p) {
+      return pos;
+    } else if (pos <= c.p + c.d.length) {
+      return c.p;
+    } else {
+      return pos - c.d.length;
+    }
+  }
+};
+
+// This helper method transforms a position by an op component.
+//
+// If c is an insert, insertAfter specifies whether the transform
+// is pushed after the insert (true) or before it (false).
+//
+// insertAfter is optional for deletes.
+// Stian 21/4/2020: Originally there was insertAfter, but this caused a
+// bug where selecting text, then deleting it by typing a letter would get
+// misinterpreted. Seems to me that we want to push the cursor even by
+// normal typing. Perhaps this is because we don't send position updates
+// when typing, while others do? Hopefully changing this doesn't introduce
+// other bugs. We duplicated the transformPosition function to not introduce
+// bugs into the core OT mechanism.
+
+var transformPositionPresence = function(pos, c, insertAfter) {
+  // This will get collapsed into a giant ternary by uglify.
+  if (c.i != null) {
+    if (c.p < pos || (c.p === pos) {
       return pos + c.i.length;
     } else {
       return pos;
@@ -177,7 +208,7 @@ var transformPosition = function(pos, c, insertAfter) {
 text.transformCursor = function(position, op, side) {
   var insertAfter = side === 'right';
   for (var i = 0; i < op.length; i++) {
-    position = transformPosition(position, op[i], insertAfter);
+    position = transformPositionPresence(position, op[i], insertAfter);
   }
 
   return position;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minervaproject/ot-json0",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "JSON OT type",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
This way the OT version is unchanged, and our changes won't cause any issues around text editing.